### PR TITLE
Optimize connection to reduce the topic/subscription existing checks

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "require": {
         "php": ">=7.1.0",
         "microsoft/windowsazure": "^0.5",
-        "ext-json": "*"
+        "ext-json": "*",
+        "psr/simple-cache": "^1.0@dev"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.1@dev",

--- a/src/Bundle/DependencyInjection/AzureMessengerAdapterExtension.php
+++ b/src/Bundle/DependencyInjection/AzureMessengerAdapterExtension.php
@@ -36,7 +36,9 @@ final class AzureMessengerAdapterExtension extends Extension
         $connectionDefinition = new Definition(Connection::class, [
             $serviceBusDefinition,
             $config['azure']['subscriptionName'],
+            $config['cache'] ? new Definition(new Reference($config['cache'])) : null,
         ]);
+
         $container->setDefinitions([
             Connection::class => $connectionDefinition,
             'azure_messenger.servicebus_builder' => $serviceBusBuilderDefinition,

--- a/src/Bundle/DependencyInjection/Configuration.php
+++ b/src/Bundle/DependencyInjection/Configuration.php
@@ -47,6 +47,10 @@ final class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->end()
+            ->scalarNode('cache')
+                ->defaultNull()
+                ->info('When the cache service is defined, it is possible to cache the subscription and topic exists checks')
+            ->end()
         ->end();
 
         return $treeBuilder;


### PR DESCRIPTION
# Todo
 - [x] When creating subscription first check topic exists
 - [x] Use simple cache to reduce the amount of topic/subscription existing checks
 - [ ] Set sleep configurable at the receiver